### PR TITLE
SSL usage fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,9 @@ Define different namespaces on a single socket. ::
     news_namespace.emit('aaa')
     socketIO.wait(seconds=1)
 
-Connect via SSL (https://github.com/invisibleroads/socketIO-client/issues/54). ::
+Connect via SSL (https://github.com/invisibleroads/socketIO-client/issues/54).
+Reliable connection using websocket transport over SSL requires openSSL
+version 1.0.2h or newer ::
 
     from socketIO_client import SocketIO
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         'requests>=2.7.0',
         'six',
-        'websocket-client'
+        'websocket-client>=0.49.0'
     ],
     tests_require=[
         'nose',

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -266,6 +266,11 @@ class EngineIO(LoggingMixin):
                     self._close()
                     raise
             except ConnectionError as e:
+                # EAGAIN or EWOULDBLOCK
+                # Ignore this error and just try again.
+                if 'Errno 11' in str(e):
+                    continue
+
                 self._opened = False
                 try:
                     warning = Exception('[connection error] %s' % e)

--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -119,6 +119,7 @@ class WebsocketTransport(AbstractTransport):
             'EIO': ENGINEIO_PROTOCOL, 'transport': 'websocket'})
         request = http_session.prepare_request(requests.Request('GET', url))
         kw = {'header': ['%s: %s' % x for x in request.headers.items()]}
+        kw['enable_multithread'] = True
         if engineIO_session:
             params['sid'] = engineIO_session.id
             kw['timeout'] = self._timeout = engineIO_session.ping_timeout


### PR DESCRIPTION
With these fixes SSL can be used with AWS ALB.
Successful tests has been performed with following setup:
```
$ openssl version
OpenSSL 1.1.0g  2 Nov 2017
$ uname -a
Linux ubu18 4.15.0-30-generic #32-Ubuntu SMP Thu Jul 26 17:42:43 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
```
OpenSSL 1.0.2g  1 Mar 2016 (the default openssl version for ubuntu 16.04) has proven itself unreliable.