### PR TITLE
avoid unexpected exceptions during wait()

### DIFF
--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -246,10 +246,12 @@ class EngineIO(LoggingMixin):
     # React
 
     def wait(self, seconds=None, **kw):
-        'Wait in a loop and react to events as defined in the namespaces'
+        # Wait in a loop and react to events as defined in the namespaces
+        if self._should_stop_waiting(**kw):
+            # no need to wait when should stop
+            return
         # Use ping/pong to unblock recv for polling transport
-        if not self._should_stop_waiting(**kw):
-            self._heartbeat_thread.hurry()
+        self._heartbeat_thread.hurry()
         # Use timeout to unblock recv for websocket transport
         self._transport.set_timeout(seconds=1)
         # Listen

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -281,7 +281,11 @@ class EngineIO(LoggingMixin):
                     pass
         if self._heartbeat_thread:
             self._heartbeat_thread.relax()
-        self._transport.set_timeout()
+        try:
+            self._transport.set_timeout()
+        except ConnectionError:
+            if not self._should_stop_waiting(**kw):
+                raise
 
     def _should_stop_waiting(self):
         return self._wants_to_close


### PR DESCRIPTION
## Status
**READY**

## Description

when wait is called during closing is in progress there is chance that `self.transport.set_timeout()` causes unexpected exceptions like `AttributeError` or `EBADF`. This changes behaviour so that wait continues only when _close is not called before (`self._wants_to_close` is not set)

 #7 was partial fix which covers only one corner case. This should cover more corner cases.

This should cover cases like:

```
  File "/builds/ws/app/socketio.py", line 223, in _runner
    self._sio.wait()
  File "/builds/ws/py2venv/local/lib/python2.7/site-packages/socketIO_client/__init__.py", line 282, in wait
    self._transport.set_timeout()
  File "/builds/ws/py2venv/local/lib/python2.7/site-packages/socketIO_client/transports.py", line 182, in set_timeout
    self._connection.settimeout(seconds or self._timeout)
  File "/builds/ws/local/lib/python2.7/site-packages/websocket/_core.py", line 146, in settimeout
    self.sock.settimeout(timeout)
AttributeError: 'NoneType' object has no attribute 'settimeout'
```

and

```
  File "/builds/ws/app/socketio.py", line 223, in _runner
    self._sio.wait()
  File "/builds/ws/py2venv/local/lib/python2.7/site-packages/socketIO_client/__init__.py", line 282, in wait
    self._transport.set_timeout()
  File "/builds/ws/py2venv/local/lib/python2.7/site-packages/socketIO_client/transports.py", line 182, in set_timeout
    self._connection.settimeout(seconds or self._timeout)
  File "/builds/ws//py2venv/local/lib/python2.7/site-packages/websocket/_core.py", line 146, in settimeout
    self.sock.settimeout(timeout)
  File "/usr/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
  File "/usr/lib/python2.7/socket.py", line 174, in _dummy
    raise error(EBADF, 'Bad file descriptor')
error: [Errno 9] Bad file descriptor
```